### PR TITLE
add version to base image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Set the base image
-FROM ubuntu
+FROM ubuntu:16.04
 # Dockerfile author / maintainer 
 MAINTAINER Alex Wu <alexanderwu@berkeley.edu>
 


### PR DESCRIPTION
If version is not specified docker uses the latest image for base container thus pulling ubuntu:18.04 which is not supported